### PR TITLE
Fix branch name in CI workflows

### DIFF
--- a/.github/workflows/linux_gnu.yml
+++ b/.github/workflows/linux_gnu.yml
@@ -1,10 +1,10 @@
 name: Linux GNU
-# triggered events (push, pull_request) for the develop branch
+# triggered events (push, pull_request) for the master branch
 on:
   push:
-    branches: [ develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ develop ]
+    branches: [ master ]
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/linux_intel.yml
+++ b/.github/workflows/linux_intel.yml
@@ -1,10 +1,10 @@
 name: Linux Intel
-# triggered events (push, pull_request) for the develop branch
+# triggered events (push, pull_request) for the master branch
 on:
   push:
-    branches: [ develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ develop ]
+    branches: [ master ]
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
The first update to the CI workflow accidentally had the wrong branch name (develop) in the config files.  This has been corrected to "master".