### PR TITLE
Add CI for MacOS

### DIFF
--- a/.github/workflows/linux_intel.yml
+++ b/.github/workflows/linux_intel.yml
@@ -83,6 +83,7 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=off ..
           make VERBOSE=1
           ctest --output-on-failure
+      # Debug session for failures
       -
         name: Debug session
         if: ${{ failure() }}

--- a/.github/workflows/linux_intel.yml
+++ b/.github/workflows/linux_intel.yml
@@ -83,6 +83,7 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=off ..
           make VERBOSE=1
           ctest --output-on-failure
+
       # Debug session for failures
       -
         name: Debug session

--- a/.github/workflows/macos_gnu.yml
+++ b/.github/workflows/macos_gnu.yml
@@ -13,7 +13,7 @@ jobs:
   macos_Build:
     name: Mac OS GNU Build
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: macos-13
 
     env:
       # Work around bug in OpenMPI: See https://github.com/open-mpi/ompi/issues/6518

--- a/.github/workflows/macos_gnu.yml
+++ b/.github/workflows/macos_gnu.yml
@@ -40,7 +40,7 @@ jobs:
           export CC=gcc-11
           export FC=gfortran-11          
           cmake -DCMAKE_BUILD_TYPE=debug -DENABLE_GPU=off .. 
-          make
+          make VERBOSE=1
           ctest --output-on-failure
           
       # Test release mode 
@@ -54,5 +54,5 @@ jobs:
           export CC=gcc-11
           export FC=gfortran-11           
           cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=off ..
-          make
+          make VERBOSE=1
           ctest --output-on-failure

--- a/.github/workflows/macos_gnu.yml
+++ b/.github/workflows/macos_gnu.yml
@@ -1,10 +1,10 @@
 name: MacOS GNU
-# triggered events (push, pull_request) for the develop branch
+# triggered events (push, pull_request) for the master branch
 on:
   push:
-    branches: [ develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ develop ]
+    branches: [ master ]
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -14,15 +14,20 @@ jobs:
     name: Mac OS GNU Build
     # The type of runner that the job will run on
     runs-on: macos-latest
+
+    env:
+      # Work around bug in OpenMPI: See https://github.com/open-mpi/ompi/issues/6518
+      OMPI_MCA_btl: "self,tcp"
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
         uses: actions/checkout@v2
-      
-      # Unlink gcc
-      - name: Unlink gcc
-        run: brew unlink gcc@9
+
+      # Install OpenMPI
+      - name: Install OpenMPI
+        run: brew install open-mpi
 
       # Test debug mode 
       - name: Test gf Debug 
@@ -31,10 +36,10 @@ jobs:
           rm -rf build
           mkdir build
           cd build
-          export OMP_NUM_THREADS=4
-          export CC=gcc-10
-          export FC=gfortran-10          
-          cmake -DCMAKE_BUILD_TYPE=debug ..
+          #export OMP_NUM_THREADS=4
+          export CC=gcc-11
+          export FC=gfortran-11          
+          cmake -DCMAKE_BUILD_TYPE=debug -DENABLE_GPU=off .. 
           make
           ctest --output-on-failure
           
@@ -45,9 +50,9 @@ jobs:
           rm -rf build
           mkdir build
           cd build
-          export OMP_NUM_THREADS=4
-          export CC=gcc-10
-          export FC=gfortran-10           
-          cmake -DCMAKE_BUILD_TYPE=release ..
+          #export OMP_NUM_THREADS=4
+          export CC=gcc-11
+          export FC=gfortran-11           
+          cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=off ..
           make
           ctest --output-on-failure

--- a/.github/workflows/macos_gnu.yml
+++ b/.github/workflows/macos_gnu.yml
@@ -56,3 +56,11 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=off ..
           make VERBOSE=1
           ctest --output-on-failure
+      # Debug session for failures
+      -
+        name: Debug session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 60
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c112cca6-12cf-4a0c-9e5e-d0d50d3b0f8b/m_RenderKit_p_2024.1.0.744_offline.dmg
+      #MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c112cca6-12cf-4a0c-9e5e-d0d50d3b0f8b/m_RenderKit_p_2024.1.0.744_offline.dmg
+      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/edb4dc2f-266f-47f2-8d56-21bc7764e119/m_HPCKit_p_2023.2.0.49443_offline.dmg
       CC: icx
       FC: ifx
 

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -18,8 +18,8 @@ jobs:
     env:
       #MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c112cca6-12cf-4a0c-9e5e-d0d50d3b0f8b/m_RenderKit_p_2024.1.0.744_offline.dmg
       MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/edb4dc2f-266f-47f2-8d56-21bc7764e119/m_HPCKit_p_2023.2.0.49443_offline.dmg
-      CC: icc
-      FC: ifort
+      CC: icx
+      FC: ifx
 
     steps:
       # Prepare for Intel cache restore
@@ -48,8 +48,8 @@ jobs:
       - name: Check compiler install
         run: |
           source /opt/intel/oneapi/setvars.sh
-          which icc
-          which ifort
+          which icx
+          which ifx
 
       # Cache OpenMPI
       - name: Cache OpenMPI
@@ -64,9 +64,8 @@ jobs:
         if: ${{ steps.cache-openmpi.outputs.cache-hit != 'true' }}
         run: |
           source /opt/intel/oneapi/setvars.sh
-          export CC="icc -m64"
-          export FC="ifort -m64"
-          export CXX="icpc -m64"
+          export CC="icx -m64"
+          export FC="ifx -m64"
           wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz
           tar -xvf ./openmpi-4.1.6.tar.gz
           cd openmpi-4.1.6
@@ -88,29 +87,29 @@ jobs:
           mkdir build
           cd build
           #export OMP_NUM_THREADS=4
-          export CC=icc
-          export FC=ifort
+          export CC=icx
+          export FC=ifx
           cmake -DCMAKE_BUILD_TYPE=debug -DCMAKE_PREFIX_PATH='~;~/openmpi' -DMPIEXEC_PREFLAGS=--oversubscribe -DENABLE_GPU=off ..
           make VERBOSE=1
           ulimit -s hard
           ctest --output-on-failure
           
       # Test release mode 
-      - name: Test gf Release
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          export PATH="${HOME}/openmpi/bin:$PATH"
-          cd ref
-          rm -rf build
-          mkdir build
-          cd build
-          #export OMP_NUM_THREADS=4
-          export CC=icc
-          export FC=ifort
-          cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_PREFIX_PATH='~;~/openmpi' -DMPIEXEC_PREFLAGS=--oversubscribe -DENABLE_GPU=off ..
-          make VERBOSE=1
-          ulimit -s hard
-          ctest --output-on-failure
+      #- name: Test gf Release
+      #  run: |
+      #    source /opt/intel/oneapi/setvars.sh
+      #    export PATH="${HOME}/openmpi/bin:$PATH"
+      #    cd ref
+      #    rm -rf build
+      #    mkdir build
+      #    cd build
+      #    #export OMP_NUM_THREADS=4
+      #    export CC=icx
+      #    export FC=ifx
+      #    cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_PREFIX_PATH='~;~/openmpi' -DMPIEXEC_PREFLAGS=--oversubscribe -DENABLE_GPU=off ..
+      #    make VERBOSE=1
+      #    ulimit -s hard
+      #    ctest --output-on-failure
       # Debug session for failures
       -
         name: Debug session

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -41,7 +41,6 @@ jobs:
           curl --output webimage.dmg --url "$MACOS_HPCKIT_URL" --retry 5 --retry-delay 5
           hdiutil attach webimage.dmg
           sudo /Volumes/$(basename $MACOS_HPCKIT_URL .dmg)/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components=all --eula=accept --continue-with-optional-error=yes --log-dir=.
-          cat /opt/intel/oneapi/logs/installer.install.intel.oneapi.mac.hpckit.*
           hdiutil detach /Volumes/$(basename "$MACOS_HPCKIT_URL" .dmg) -quiet
 
       # Check location of installed Intel compilers

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -51,6 +51,28 @@ jobs:
           which icc
           which ifort
 
+      # Cache OpenMPI
+      - name: Cache OpenMPI
+        uses: actions/cache@v3
+        id:   cache-openmpi
+        with:
+          path: ~/openmpi
+          key:  openmpi-4.0.2-${{ runner.os }}-intel
+
+      # Install OpenMPI
+      - name: Install OpenMPI
+        if: ${{ steps.cache-openmpi.outputs.cache-hit != 'true' }}
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          export CC="icc -m64"
+          export FC="ifort -m64"
+          wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.2.tar.gz
+          tar -xvf ./openmpi-4.0.2.tar.gz
+          cd openmpi-4.0.2
+          ./configure --prefix=${HOME}/openmpi
+          make -j2
+          sudo make install
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -66,6 +66,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           export CC="icc -m64"
           export FC="ifort -m64"
+	  export CXX="icpc -m64"
           wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.2.tar.gz
           tar -xvf ./openmpi-4.0.2.tar.gz
           cd openmpi-4.0.2

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -13,7 +13,7 @@ jobs:
   macos_Build:
     name: Mac OS Intel Build
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: macos-13
 
     env:
       #MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c112cca6-12cf-4a0c-9e5e-d0d50d3b0f8b/m_RenderKit_p_2024.1.0.744_offline.dmg

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -1,10 +1,10 @@
 name: MacOS Intel
-# triggered events (push, pull_request) for the develop branch
+# triggered events (push, pull_request) for the master branch
 on:
   push:
-    branches: [ develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ develop ]
+    branches: [ master ]
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -16,10 +16,9 @@ jobs:
     runs-on: macos-latest
 
     env:
-      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/17643/m_HPCKit_p_2021.2.0.2903_offline.dmg
-      CC: icc
-      FC: ifort
-      CXX: icpc
+      MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c112cca6-12cf-4a0c-9e5e-d0d50d3b0f8b/m_RenderKit_p_2024.1.0.744_offline.dmg
+      CC: icx
+      FC: ifx
 
     steps:
       # Prepare for Intel cache restore
@@ -49,8 +48,8 @@ jobs:
       - name: Check compiler install
         run: |
           source /opt/intel/oneapi/setvars.sh
-          which icc
-          which ifort
+          which icx
+          which ifx
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
@@ -64,11 +63,11 @@ jobs:
           rm -rf build
           mkdir build
           cd build
-          export OMP_NUM_THREADS=4
-          export CC=icc
-          export FC=ifort
-          cmake -DCMAKE_BUILD_TYPE=debug ..
-          make
+          #export OMP_NUM_THREADS=4
+          export CC=icx
+          export FC=ifx
+          cmake -DCMAKE_BUILD_TYPE=debug -DENABLE_GPU=off ..
+          make VERBOSE=1
           ulimit -s hard
           ctest --output-on-failure
           
@@ -80,10 +79,10 @@ jobs:
           rm -rf build
           mkdir build
           cd build
-          export OMP_NUM_THREADS=4
-          export CC=icc
-          export FC=ifort
-          cmake -DCMAKE_BUILD_TYPE=release ..
-          make
+          #export OMP_NUM_THREADS=4
+          export CC=icx
+          export FC=ifx
+          cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=off ..
+          make VERBOSE=1
           ulimit -s hard
           ctest --output-on-failure

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -57,7 +57,7 @@ jobs:
         id:   cache-openmpi
         with:
           path: ~/openmpi
-          key:  openmpi-4.0.2-${{ runner.os }}-intel
+          key:  openmpi-4.1.6-${{ runner.os }}-intel
 
       # Install OpenMPI
       - name: Install OpenMPI
@@ -67,9 +67,9 @@ jobs:
           export CC="icc -m64"
           export FC="ifort -m64"
           export CXX="icpc -m64"
-          wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.2.tar.gz
-          tar -xvf ./openmpi-4.0.2.tar.gz
-          cd openmpi-4.0.2
+          wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz
+          tar -xvf ./openmpi-4.1.6.tar.gz
+          cd openmpi-4.1.6
           ./configure --prefix=${HOME}/openmpi
           make -j2
           sudo make install

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -16,10 +16,9 @@ jobs:
     runs-on: macos-13
 
     env:
-      #MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c112cca6-12cf-4a0c-9e5e-d0d50d3b0f8b/m_RenderKit_p_2024.1.0.744_offline.dmg
       MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/edb4dc2f-266f-47f2-8d56-21bc7764e119/m_HPCKit_p_2023.2.0.49443_offline.dmg
-      CC: icx
-      FC: ifx
+      CC: icc
+      FC: ifort
 
     steps:
       # Prepare for Intel cache restore
@@ -48,8 +47,8 @@ jobs:
       - name: Check compiler install
         run: |
           source /opt/intel/oneapi/setvars.sh
-          which icx
-          which ifx
+          which icc
+          which ifort
 
       # Cache OpenMPI
       - name: Cache OpenMPI
@@ -64,8 +63,8 @@ jobs:
         if: ${{ steps.cache-openmpi.outputs.cache-hit != 'true' }}
         run: |
           source /opt/intel/oneapi/setvars.sh
-          export CC="icx -m64"
-          export FC="ifx -m64"
+          export CC="icc -m64"
+          export FC="ifort -m64"
           wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.6.tar.gz
           tar -xvf ./openmpi-4.1.6.tar.gz
           cd openmpi-4.1.6
@@ -87,8 +86,8 @@ jobs:
           mkdir build
           cd build
           #export OMP_NUM_THREADS=4
-          export CC=icx
-          export FC=ifx
+          export CC=icc
+          export FC=ifort
           cmake -DCMAKE_BUILD_TYPE=debug -DCMAKE_PREFIX_PATH='~;~/openmpi' -DMPIEXEC_PREFLAGS=--oversubscribe -DENABLE_GPU=off ..
           make VERBOSE=1
           ulimit -s hard
@@ -104,8 +103,8 @@ jobs:
       #    mkdir build
       #    cd build
       #    #export OMP_NUM_THREADS=4
-      #    export CC=icx
-      #    export FC=ifx
+      #    export CC=icc
+      #    export FC=ifort
       #    cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_PREFIX_PATH='~;~/openmpi' -DMPIEXEC_PREFLAGS=--oversubscribe -DENABLE_GPU=off ..
       #    make VERBOSE=1
       #    ulimit -s hard

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -85,3 +85,11 @@ jobs:
           make VERBOSE=1
           ulimit -s hard
           ctest --output-on-failure
+      # Debug session for failures
+      -
+        name: Debug session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 60
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -93,7 +93,8 @@ jobs:
           ulimit -s hard
           ctest --output-on-failure
           
-      # Test release mode 
+      # Test release mode
+      # INTEL CLASSIC COMPILERS HANG WHILE BUILDING cu_gf_deep.F90, TURN OFF FOR NOW
       #- name: Test gf Release
       #  run: |
       #    source /opt/intel/oneapi/setvars.sh
@@ -109,6 +110,7 @@ jobs:
       #    make VERBOSE=1
       #    ulimit -s hard
       #    ctest --output-on-failure
+
       # Debug session for failures
       -
         name: Debug session

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -18,8 +18,8 @@ jobs:
     env:
       #MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c112cca6-12cf-4a0c-9e5e-d0d50d3b0f8b/m_RenderKit_p_2024.1.0.744_offline.dmg
       MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/edb4dc2f-266f-47f2-8d56-21bc7764e119/m_HPCKit_p_2023.2.0.49443_offline.dmg
-      CC: icx
-      FC: ifx
+      CC: icc
+      FC: ifort
 
     steps:
       # Prepare for Intel cache restore
@@ -48,8 +48,8 @@ jobs:
       - name: Check compiler install
         run: |
           source /opt/intel/oneapi/setvars.sh
-          which icx
-          which ifx
+          which icc
+          which ifort
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
@@ -64,8 +64,8 @@ jobs:
           mkdir build
           cd build
           #export OMP_NUM_THREADS=4
-          export CC=icx
-          export FC=ifx
+          export CC=icc
+          export FC=ifort
           cmake -DCMAKE_BUILD_TYPE=debug -DENABLE_GPU=off ..
           make VERBOSE=1
           ulimit -s hard
@@ -80,8 +80,8 @@ jobs:
           mkdir build
           cd build
           #export OMP_NUM_THREADS=4
-          export CC=icx
-          export FC=ifx
+          export CC=icc
+          export FC=ifort
           cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=off ..
           make VERBOSE=1
           ulimit -s hard

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -66,7 +66,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           export CC="icc -m64"
           export FC="ifort -m64"
-	  export CXX="icpc -m64"
+          export CXX="icpc -m64"
           wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.2.tar.gz
           tar -xvf ./openmpi-4.0.2.tar.gz
           cd openmpi-4.0.2

--- a/.github/workflows/macos_intel.yml
+++ b/.github/workflows/macos_intel.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Test gf Debug 
         run: |
           source /opt/intel/oneapi/setvars.sh
+          export PATH="${HOME}/openmpi/bin:$PATH"
           cd ref
           rm -rf build
           mkdir build
@@ -89,7 +90,7 @@ jobs:
           #export OMP_NUM_THREADS=4
           export CC=icc
           export FC=ifort
-          cmake -DCMAKE_BUILD_TYPE=debug -DENABLE_GPU=off ..
+          cmake -DCMAKE_BUILD_TYPE=debug -DCMAKE_PREFIX_PATH='~;~/openmpi' -DMPIEXEC_PREFLAGS=--oversubscribe -DENABLE_GPU=off ..
           make VERBOSE=1
           ulimit -s hard
           ctest --output-on-failure
@@ -98,6 +99,7 @@ jobs:
       - name: Test gf Release
         run: |
           source /opt/intel/oneapi/setvars.sh
+          export PATH="${HOME}/openmpi/bin:$PATH"
           cd ref
           rm -rf build
           mkdir build
@@ -105,7 +107,7 @@ jobs:
           #export OMP_NUM_THREADS=4
           export CC=icc
           export FC=ifort
-          cmake -DCMAKE_BUILD_TYPE=release -DENABLE_GPU=off ..
+          cmake -DCMAKE_BUILD_TYPE=release -DCMAKE_PREFIX_PATH='~;~/openmpi' -DMPIEXEC_PREFLAGS=--oversubscribe -DENABLE_GPU=off ..
           make VERBOSE=1
           ulimit -s hard
           ctest --output-on-failure


### PR DESCRIPTION
Adds CI workflows for MacOS.  Note: LLVM Intel compilers are not available on MacOS and Intel Classic compiler `ifort` hangs while compiling `cu_gf_deep.F90` at `-O3`.  So release mode is not checked for Intel on Mac yet.